### PR TITLE
Fix python_version format

### DIFF
--- a/mysql.json
+++ b/mysql.json
@@ -14,10 +14,7 @@
     "utctime_updated": "2025-07-30T17:50:38.368632Z",
     "package_name": "phantom_mysql",
     "main_module": "mysql_connector.py",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "min_phantom_version": "5.1.0",
     "fips_compliant": true,
     "latest_tested_versions": [

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)