### PR TITLE
fix!: enforce MySQL TLS verification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.4
     hooks:
       - id: build-docs
         language: python

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Splunk SOAR App: MySQL
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.
 Third Party Software Attributions:
 
 @@@@============================================================================
@@ -28,4 +28,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 **username** | required | string | Username |
 **password** | required | password | Password |
 **database** | required | string | Database Name |
-**verify_ssl** | optional | boolean | Verify server certificate |
+**verify_ssl** | optional | boolean | Verify the server certificate. Disabling verification exposes database credentials and query results to network attackers. |
 
 ### Supported Actions
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mysql.json
+++ b/mysql.json
@@ -9,7 +9,7 @@
     "product_name": "MySQL",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "app_version": "2.1.9",
     "utctime_updated": "2025-12-22T21:30:22.939580Z",
     "package_name": "phantom_mysql",

--- a/mysql.json
+++ b/mysql.json
@@ -48,8 +48,8 @@
         },
         "verify_ssl": {
             "data_type": "boolean",
-            "description": "Verify server certificate",
-            "default": false,
+            "description": "Verify the server certificate. Disabling verification exposes database credentials and query results to network attackers.",
+            "default": true,
             "order": 4
         }
     },

--- a/mysql_connector.py
+++ b/mysql_connector.py
@@ -1,6 +1,6 @@
 # File: mysql_connector.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mysql_connector.py
+++ b/mysql_connector.py
@@ -232,14 +232,15 @@ class MysqlConnector(BaseConnector):
             # Defaults to False for backward compatibility with self-signed certificates
             # Python 3.13 has stricter SSL/TLS defaults, so explicit configuration is required
             verify_ssl = config.get(MYSQL_VERIFY_SERVER_CERT_JSON, False)
-            ssl_config = {"ssl_verify_cert": verify_ssl, "ssl_verify_identity": verify_ssl}
-
             self._my_connection = pymysql.connect(
                 user=config[MYSQL_USERNAME_JSON],
                 password=config[MYSQL_PASSWORD_JSON],
                 database=config[MYSQL_DATABASE_JSON],
                 host=config[MYSQL_HOST_JSON],
-                ssl=ssl_config,
+                # Preserve encrypted transport for an explicit verification opt-out.
+                ssl={"ca": None},
+                ssl_verify_cert=verify_ssl,
+                ssl_verify_identity=verify_ssl,
             )
             # self._my_connection.autocommit = True
         except pymysql.Error as e:

--- a/mysql_connector.py
+++ b/mysql_connector.py
@@ -229,9 +229,8 @@ class MysqlConnector(BaseConnector):
         self.save_progress(MYSQL_INIT_DB_CONNECTION_MSG)
         try:
             # Configure SSL certificate verification based on asset setting
-            # Defaults to False for backward compatibility with self-signed certificates
-            # Python 3.13 has stricter SSL/TLS defaults, so explicit configuration is required
-            verify_ssl = config.get(MYSQL_VERIFY_SERVER_CERT_JSON, False)
+            # Require an explicit opt-out for deployments that use untrusted certificates.
+            verify_ssl = config.get(MYSQL_VERIFY_SERVER_CERT_JSON, True)
             self._my_connection = pymysql.connect(
                 user=config[MYSQL_USERNAME_JSON],
                 password=config[MYSQL_PASSWORD_JSON],

--- a/mysql_consts.py
+++ b/mysql_consts.py
@@ -1,6 +1,6 @@
 # File: mysql_consts.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/mysql_run_query.html
+++ b/mysql_run_query.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!--  File: mysql_run_query.html
-  Copyright (c) 2017-2025 Splunk Inc.
+  Copyright (c) 2017-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/mysql_view.py
+++ b/mysql_view.py
@@ -1,6 +1,6 @@
 # File: mysql_view.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/readme.html
+++ b/readme.html
@@ -1,5 +1,5 @@
 <!-- File: readme.html
-  Copyright (c) 2017-2025 Splunk Inc.
+  Copyright (c) 2017-2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Apply the server-certificate verification setting through the supported PyMySQL connection options.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Apply the server-certificate verification setting through the supported PyMySQL connection options.
+* Enable server-certificate verification by default while retaining an explicit opt-out.


### PR DESCRIPTION
## Summary

- wire certificate-chain and hostname verification through supported PyMySQL connection options
- preserve encrypted transport for an explicit verification opt-out
- enable certificate verification by default and document the opt-out risk
- refresh shared hooks and generated metadata

Tracks PAPP-38260. Addresses PSAAS-31273 and PSAAS-30778 under ESPM-5228.

## Breaking change

Assets that do not explicitly disable verification now require a server certificate trusted for the configured hostname.

## Validation

- `pre-commit run --all-files`
- `python3 -m compileall -q -x .*/\.venv/.* .`

PR and changes prepared by Codex.

## Tracking

- PAPP: PAPP-38260
- PSAAS: PSAAS-30778, PSAAS-31273
- Written by Codex.