### PR TITLE
fix: enforce verified MySQL TLS

### DIFF
--- a/mysql_connector.py
+++ b/mysql_connector.py
@@ -19,6 +19,7 @@ import csv
 import datetime
 import json
 import re
+import ssl
 
 import phantom.app as phantom
 import pymysql
@@ -231,15 +232,16 @@ class MysqlConnector(BaseConnector):
             # Configure SSL certificate verification based on asset setting
             # Require an explicit opt-out for deployments that use untrusted certificates.
             verify_ssl = config.get(MYSQL_VERIFY_SERVER_CERT_JSON, True)
+            ssl_context = ssl.create_default_context()
+            if not verify_ssl:
+                ssl_context.check_hostname = False
+                ssl_context.verify_mode = ssl.CERT_NONE
             self._my_connection = pymysql.connect(
                 user=config[MYSQL_USERNAME_JSON],
                 password=config[MYSQL_PASSWORD_JSON],
                 database=config[MYSQL_DATABASE_JSON],
                 host=config[MYSQL_HOST_JSON],
-                # Preserve encrypted transport for an explicit verification opt-out.
-                ssl={"ca": None},
-                ssl_verify_cert=verify_ssl,
-                ssl_verify_identity=verify_ssl,
+                ssl=ssl_context,
             )
             # self._my_connection.autocommit = True
         except pymysql.Error as e:

--- a/mysql_connector.py
+++ b/mysql_connector.py
@@ -27,6 +27,7 @@ from phantom.action_result import ActionResult
 from phantom.base_connector import BaseConnector
 
 from mysql_consts import *
+from mysql_tls import TlsRequiredConnection
 
 
 class RetVal(tuple):
@@ -236,7 +237,7 @@ class MysqlConnector(BaseConnector):
             if verify_ssl is False:
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = ssl.CERT_NONE
-            self._my_connection = pymysql.connect(
+            self._my_connection = TlsRequiredConnection(
                 user=config[MYSQL_USERNAME_JSON],
                 password=config[MYSQL_PASSWORD_JSON],
                 database=config[MYSQL_DATABASE_JSON],

--- a/mysql_connector.py
+++ b/mysql_connector.py
@@ -233,7 +233,7 @@ class MysqlConnector(BaseConnector):
             # Require an explicit opt-out for deployments that use untrusted certificates.
             verify_ssl = config.get(MYSQL_VERIFY_SERVER_CERT_JSON, True)
             ssl_context = ssl.create_default_context()
-            if not verify_ssl:
+            if verify_ssl is False:
                 ssl_context.check_hostname = False
                 ssl_context.verify_mode = ssl.CERT_NONE
             self._my_connection = pymysql.connect(

--- a/mysql_tls.py
+++ b/mysql_tls.py
@@ -1,0 +1,35 @@
+# File: mysql_tls.py
+#
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+import pymysql
+from pymysql.constants import CLIENT, CR
+
+
+def require_tls_capability(server_capabilities):
+    """Reject a server that cannot negotiate TLS before authentication begins."""
+    if not server_capabilities & CLIENT.SSL:
+        raise pymysql.err.OperationalError(
+            CR.CR_SSL_CONNECTION_ERROR,
+            "The MySQL server did not advertise required TLS support",
+        )
+
+
+class TlsRequiredConnection(pymysql.connections.Connection):
+    """PyMySQL connection that refuses plaintext authentication fallback."""
+
+    def _get_server_information(self):
+        super()._get_server_information()
+        if self.ssl:
+            require_tls_capability(self.server_capabilities)

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Preserve certificate hostname verification for trusted MySQL connections

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -2,3 +2,4 @@
 
 * Preserve certificate hostname verification for trusted MySQL connections
 * Require an explicit boolean opt-out before disabling certificate verification
+* Reject servers that do not negotiate TLS before database authentication

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Preserve certificate hostname verification for trusted MySQL connections
+* Require an explicit boolean opt-out before disabling certificate verification

--- a/tests/test_tls_policy.py
+++ b/tests/test_tls_policy.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2026 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied. See the License for the specific language governing permissions
+# and limitations under the License.
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+import pymysql
+from pymysql.constants import CLIENT, CR
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "mysql_tls.py"
+SPEC = importlib.util.spec_from_file_location("mysql_tls", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+MYSQL_TLS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MYSQL_TLS)
+require_tls_capability = MYSQL_TLS.require_tls_capability
+
+
+class TlsPolicyTests(unittest.TestCase):
+    def test_tls_capability_is_required_before_authentication(self):
+        with self.assertRaises(pymysql.err.OperationalError) as exc_info:
+            require_tls_capability(0)
+
+        self.assertEqual(exc_info.exception.args[0], CR.CR_SSL_CONNECTION_ERROR)
+
+    def test_tls_capability_allows_encrypted_handshake(self):
+        require_tls_capability(CLIENT.SSL)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Authored by Codex.

## Summary

- construct a standard SSL context for MySQL connections
- retain both CA trust and hostname verification whenever `verify_ssl` is enabled
- treat only an explicit boolean `false` as the administrator opt-out
- abort before authentication if the server does not negotiate TLS
- apply the shared connection behavior to every connector action
- add source-level regression coverage for TLS capability enforcement

## Validation

- `python3 -m py_compile mysql_connector.py mysql_consts.py mysql_tls.py mysql_view.py __init__.py`
- `PYTHONPATH=wheels/py3/pymysql-1.1.2-py3-none-any.whl .venv/bin/python -m unittest discover -s tests -q`
- `pre-commit run --all-files`
- hosted `pre-commit` and `compile` passed at `7fc0e3886adac36deb8f43c193f126d7d5286840`

## Tracking

- [PSAAS-30778](https://splunk.atlassian.net/browse/PSAAS-30778)
- [PSAAS-31273](https://splunk.atlassian.net/browse/PSAAS-31273)
- PAPP-38260
- Parent epic: ESPM-5228

Merge strategy: merge commit only; do not squash.
